### PR TITLE
feat: 更新网站内容

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,13 +98,13 @@
             </h2>
             <div class="space-y-1" role="list">
               <article class="flex items-start" role="listitem">
-                <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2025-06">2025-06</time>
+                <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2025-09">2025-09</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
-                    <a href="https://www.bilibili.com/video/BV1hw7hzPECb/?spm_id_from=333.1387.homepage.video_card.click&vd_source=a5d50e36600079d7178bdd0fe9f282dd" target="_blank" class="text-gray-700 hover:text-black" aria-label="Galacean 引擎 1.5 发布，新增 AI 图生 3D - 在新窗口打开" data-zh="Galacean 引擎 1.5 发布，新增 AI 图生 3D" data-en="Galacean Engine 1.5 Released with New AI Image-to-3D Feature">Galacean 引擎 1.5 发布，新增 AI 图生 3D</a>
+                    <a href="https://neovateai.dev/zh-CN/blog/neovate-code-is-open-sourced/" target="_blank" class="text-gray-700 hover:text-black" aria-label="Neovate Code 现已开源 - 在新窗口打开" data-zh="Neovate Code 现已开源" data-en="Neovate Code is Now Open Source">Neovate Code 现已开源</a>
                   </h3>
-                  <p class="text-sm tracking-wide" data-zh="Galacean 引擎发布 1.5 版本，新增 AI 图生 3D 功能，为前端开发者提供更强大的 3D 渲染能力。" data-en="Galacean Engine releases version 1.5 with new AI image-to-3D functionality, providing frontend developers with more powerful 3D rendering capabilities.">
-                    Galacean 引擎发布 1.5 版本，新增 AI 图生 3D 功能，为前端开发者提供更强大的 3D 渲染能力。
+                  <p class="text-sm tracking-wide" data-zh="AI 驱动的编程助手 Neovate Code 正式开源，提供代码生成、错误修复、代码审查等功能，支持交互模式和无头模式。" data-en="AI-driven programming assistant Neovate Code is officially open source, providing code generation, bug fixes, code review and other features, supporting interactive and headless modes.">
+                    AI 驱动的编程助手 Neovate Code 正式开源，提供代码生成、错误修复、代码审查等功能，支持交互模式和无头模式。
                   </p>
                 </div>
               </article>
@@ -150,6 +150,14 @@
               博客文章
             </h2>
             <div class="space-y-1" role="list">
+              <article class="list-item-with-border" role="listitem">
+                <h3 class="font-semibold text-base mb-1 tracking-wide">
+                  <a href="https://mp.weixin.qq.com/s/vRlkkQGhIxGJAD4EYshflw" target="_blank" class="hover:text-black" aria-label="智能编程助手 Neovate Code 正式开源 - 在新窗口打开" data-zh="智能编程助手 Neovate Code 正式开源" data-en="Intelligent Programming Assistant Neovate Code is Officially Open Source">智能编程助手 Neovate Code 正式开源</a>
+                </h3>
+                <div class="text-sm text-gray-600 tracking-wide" data-zh="云谦 · 2025年09月24日" data-en="Yun Qian · Sep 24, 2025">
+                  云谦 · 2025年09月24日
+                </div>
+              </article>
               <article class="list-item-with-border" role="listitem">
                 <h3 class="font-semibold text-base mb-1 tracking-wide">
                   <a href="https://mp.weixin.qq.com/s/CdCvCzfycme6rw4OKa_1aA" target="_blank" class="hover:text-black" aria-label="MCP 在蚂蚁前端的落地之旅 - 在新窗口打开" data-zh="MCP 在蚂蚁前端的落地之旅" data-en="MCP Landing Journey in Ant Frontend">MCP 在蚂蚁前端的落地之旅</a>
@@ -244,12 +252,34 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
+                    <a href="https://github.com/utooland/utoo" target="_blank" class="hover:text-black" aria-label="utoo GitHub 仓库 - 在新窗口打开">utoo</a>
+                  </h3>
+                  <a href="https://github.com/utooland/utoo" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="utoo GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                </div>
+                <p class="text-sm mb-1 tracking-wide" data-zh="Web 开发的统一工具链，提供一站式的开发体验和工具集成。" data-en="An unified toolchain for web development, providing one-stop development experience and tool integration.">
+                  Web 开发的统一工具链，提供一站式的开发体验和工具集成。
+                </p>
+              </article>
+              <article class="pb-1" role="listitem">
+                <div class="flex justify-between items-start mb-1">
+                  <h3 class="font-semibold text-base tracking-wide">
                     <a href="https://github.com/cnpm/cnpm" target="_blank" class="hover:text-black" aria-label="cnpm GitHub 仓库 - 在新窗口打开">cnpm</a>
                   </h3>
                   <a href="https://github.com/cnpm/cnpm" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="cnpm GitHub 仓库 - 在新窗口打开">GitHub →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="npm 的中国镜像客户端，为中国前端开发者提供更快的包管理体验和镜像服务。" data-en="npm's China mirror client, providing Chinese frontend developers with faster package management experience and mirror services.">
                   npm 的中国镜像客户端，为中国前端开发者提供更快的包管理体验和镜像服务。
+                </p>
+              </article>
+              <article class="pb-1" role="listitem">
+                <div class="flex justify-between items-start mb-1">
+                  <h3 class="font-semibold text-base tracking-wide">
+                    <a href="https://github.com/petercat-ai/petercat" target="_blank" class="hover:text-black" aria-label="PeterCat GitHub 仓库 - 在新窗口打开">PeterCat</a>
+                  </h3>
+                  <a href="https://github.com/petercat-ai/petercat" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="PeterCat GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                </div>
+                <p class="text-sm mb-1 tracking-wide" data-zh="一个对话式问答代理配置系统，提供自托管部署解决方案和便捷的一体化应用 SDK，让你为 GitHub 仓库创建智能问答机器人。" data-en="A conversational Q&A agent configuration system, self-hosted deployment solutions, and a convenient all-in-one application SDK, allowing you to create intelligent Q&A bots for your GitHub repositories.">
+                  一个对话式问答代理配置系统，提供自托管部署解决方案和便捷的一体化应用 SDK，让你为 GitHub 仓库创建智能问答机器人。
                 </p>
               </article>
               <article class="pb-1" role="listitem">
@@ -266,6 +296,17 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
+                    <a href="https://github.com/neovateai/neovate-code" target="_blank" class="hover:text-black" aria-label="Neovate Code GitHub 仓库 - 在新窗口打开">Neovate Code</a>
+                  </h3>
+                  <a href="https://github.com/neovateai/neovate-code" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="Neovate Code GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                </div>
+                <p class="text-sm mb-1 tracking-wide" data-zh="代码智能助手，可以用来生成代码、修复错误、审查代码、添加测试等，支持交互模式和无头模式。" data-en="Code agent to enhance your development. You can use it to generate code, fix bugs, review code, add tests, and more. You can run it in interactive mode or headless mode.">
+                  代码智能助手，可以用来生成代码、修复错误、审查代码、添加测试等，支持交互模式和无头模式。
+                </p>
+              </article>
+              <article class="pb-1" role="listitem">
+                <div class="flex justify-between items-start mb-1">
+                  <h3 class="font-semibold text-base tracking-wide">
                     <a href="https://github.com/unieojs/unieo" target="_blank" class="hover:text-black" aria-label="Unieo GitHub 仓库 - 在新窗口打开">Unieo</a>
                   </h3>
                   <a href="https://github.com/unieojs/unieo" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="Unieo GitHub 仓库 - 在新窗口打开">GitHub →</a>
@@ -277,12 +318,12 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://github.com/petercat-ai/petercat" target="_blank" class="hover:text-black" aria-label="PeterCat GitHub 仓库 - 在新窗口打开">PeterCat</a>
+                    <a href="https://github.com/petercat-ai/WhiskerRAG" target="_blank" class="hover:text-black" aria-label="WhiskerRAG GitHub 仓库 - 在新窗口打开">WhiskerRAG</a>
                   </h3>
-                  <a href="https://github.com/petercat-ai/petercat" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="PeterCat GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                  <a href="https://github.com/petercat-ai/WhiskerRAG" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="WhiskerRAG GitHub 仓库 - 在新窗口打开">GitHub →</a>
                 </div>
-                <p class="text-sm mb-1 tracking-wide" data-zh="一个对话式问答代理配置系统，提供自托管部署解决方案和便捷的一体化应用 SDK，让你为 GitHub 仓库创建智能问答机器人。" data-en="A conversational Q&A agent configuration system, self-hosted deployment solutions, and a convenient all-in-one application SDK, allowing you to create intelligent Q&A bots for your GitHub repositories.">
-                  一个对话式问答代理配置系统，提供自托管部署解决方案和便捷的一体化应用 SDK，让你为 GitHub 仓库创建智能问答机器人。
+                <p class="text-sm mb-1 tracking-wide" data-zh="轻量级且灵活的 RAG（检索增强生成）框架，提供高效的知识检索和生成能力。" data-en="A lightweight and flexible RAG (Retrieval-Augmented Generation) framework.">
+                  轻量级且灵活的 RAG（检索增强生成）框架，提供高效的知识检索和生成能力。
                 </p>
               </article>
             </div>
@@ -298,16 +339,20 @@
             </h2>
             <div class="space-y-1" role="list">
               <article class="flex justify-between items-center py-1" role="listitem">
-                <a href="https://talent.antgroup.com/off-campus-position?positionId=25042804570964" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="体验技术产品专家岗位详情 - 在新窗口打开" data-zh="体验技术产品专家" data-en="Experience Technology Product Expert">体验技术产品专家</a>
-                <a href="https://talent.antgroup.com/off-campus-position?positionId=25042804570964" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="体验技术产品专家岗位详情 - 在新窗口打开" data-zh="查看详情" data-en="View Details">查看详情 →</a>
+                <a href="https://talent.antgroup.com/off-campus-position?positionId=25082006360180&tid=0b22831417587975758658512e57df" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="Node.js （前端 AI 基础设施方向）岗位详情 - 在新窗口打开" data-zh="Node.js （前端 AI 基础设施方向）" data-en="Node.js (Frontend AI Infrastructure Direction)">Node.js （前端 AI 基础设施方向）</a>
+                <a href="https://talent.antgroup.com/off-campus-position?positionId=25082006360180&tid=0b22831417587975758658512e57df" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="Node.js （前端 AI 基础设施方向）岗位详情 - 在新窗口打开" data-zh="查看详情" data-en="View Details">查看详情 →</a>
               </article>
               <article class="flex justify-between items-center py-1" role="listitem">
-                <a href="https://talent.antgroup.com/off-campus-position?positionId=1944823" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="前端开发专家岗位详情 - 在新窗口打开" data-zh="前端开发专家" data-en="Frontend Development Expert">前端开发专家</a>
-                <a href="https://talent.antgroup.com/off-campus-position?positionId=1944823" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="前端开发专家岗位详情 - 在新窗口打开" data-zh="查看详情" data-en="View Details">查看详情 →</a>
+                <a href="https://talent.antgroup.com/off-campus-position?positionId=25082706463820&tid=0b22831417587975758658512e57df" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="前端开发（AI技术产品方向）岗位详情 - 在新窗口打开" data-zh="前端开发（AI技术产品方向）" data-en="Frontend Development (AI Technology Product Direction)">前端开发（AI技术产品方向）</a>
+                <a href="https://talent.antgroup.com/off-campus-position?positionId=25082706463820&tid=0b22831417587975758658512e57df" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="前端开发（AI技术产品方向）岗位详情 - 在新窗口打开" data-zh="查看详情" data-en="View Details">查看详情 →</a>
               </article>
               <article class="flex justify-between items-center py-1" role="listitem">
-                <a href="https://talent.antgroup.com/off-campus-position?positionId=1948101" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="前端开发（应用智作）岗位详情 - 在新窗口打开" data-zh="前端开发（应用智作）" data-en="Frontend Developer (Application Intelligence)">前端开发（应用智作）</a>
-                <a href="https://talent.antgroup.com/off-campus-position?positionId=1948101" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="前端开发（应用智作）岗位详情 - 在新窗口打开" data-zh="查看详情" data-en="View Details">查看详情 →</a>
+                <a href="https://talent.antgroup.com/off-campus-position?positionId=25082706461865&tid=0b22831417587975758658512e57df" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="数据研发岗位详情 - 在新窗口打开" data-zh="数据研发" data-en="Data Research and Development">数据研发</a>
+                <a href="https://talent.antgroup.com/off-campus-position?positionId=25082706461865&tid=0b22831417587975758658512e57df" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="数据研发岗位详情 - 在新窗口打开" data-zh="查看详情" data-en="View Details">查看详情 →</a>
+              </article>
+              <article class="flex justify-between items-center py-1" role="listitem">
+                <a href="https://talent.antgroup.com/off-campus-position?positionId=25082706460510&tid=0b22831417587975758658512e57df" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="产品经理（数据产品、AI产品方向）岗位详情 - 在新窗口打开" data-zh="产品经理（数据产品、AI产品方向）" data-en="Product Manager (Data Products, AI Products Direction)">产品经理（数据产品、AI产品方向）</a>
+                <a href="https://talent.antgroup.com/off-campus-position?positionId=25082706460510&tid=0b22831417587975758658512e57df" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="产品经理（数据产品、AI产品方向）岗位详情 - 在新窗口打开" data-zh="查看详情" data-en="View Details">查看详情 →</a>
               </article>
             </div>
             <aside class="mt-2 p-2 bg-gray-50 border-l-2 border-gray-400">

--- a/index.html
+++ b/index.html
@@ -339,19 +339,19 @@
             </h2>
             <div class="space-y-1" role="list">
               <article class="flex justify-between items-center py-1" role="listitem">
-                <a href="https://talent.antgroup.com/off-campus-position?positionId=25082006360180&tid=0b22831417587975758658512e57df" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="Node.js （前端 AI 基础设施方向）岗位详情 - 在新窗口打开" data-zh="Node.js （前端 AI 基础设施方向）" data-en="Node.js (Frontend AI Infrastructure Direction)">Node.js （前端 AI 基础设施方向）</a>
+                <a href="https://talent.antgroup.com/off-campus-position?positionId=25082006360180&tid=0b22831417587975758658512e57df" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="Node.js （前端 AI 基础设施方向）岗位详情 - 在新窗口打开" data-zh="Node.js （前端 AI 基础设施方向）" data-en="Node.js Engineer">Node.js （前端 AI 基础设施方向）</a>
                 <a href="https://talent.antgroup.com/off-campus-position?positionId=25082006360180&tid=0b22831417587975758658512e57df" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="Node.js （前端 AI 基础设施方向）岗位详情 - 在新窗口打开" data-zh="查看详情" data-en="View Details">查看详情 →</a>
               </article>
               <article class="flex justify-between items-center py-1" role="listitem">
-                <a href="https://talent.antgroup.com/off-campus-position?positionId=25082706463820&tid=0b22831417587975758658512e57df" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="前端开发（AI技术产品方向）岗位详情 - 在新窗口打开" data-zh="前端开发（AI技术产品方向）" data-en="Frontend Development (AI Technology Product Direction)">前端开发（AI技术产品方向）</a>
+                <a href="https://talent.antgroup.com/off-campus-position?positionId=25082706463820&tid=0b22831417587975758658512e57df" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="前端开发（AI技术产品方向）岗位详情 - 在新窗口打开" data-zh="前端开发（AI技术产品方向）" data-en="Frontend Developer (AI)">前端开发（AI技术产品方向）</a>
                 <a href="https://talent.antgroup.com/off-campus-position?positionId=25082706463820&tid=0b22831417587975758658512e57df" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="前端开发（AI技术产品方向）岗位详情 - 在新窗口打开" data-zh="查看详情" data-en="View Details">查看详情 →</a>
               </article>
               <article class="flex justify-between items-center py-1" role="listitem">
-                <a href="https://talent.antgroup.com/off-campus-position?positionId=25082706461865&tid=0b22831417587975758658512e57df" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="数据研发岗位详情 - 在新窗口打开" data-zh="数据研发" data-en="Data Research and Development">数据研发</a>
+                <a href="https://talent.antgroup.com/off-campus-position?positionId=25082706461865&tid=0b22831417587975758658512e57df" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="数据研发岗位详情 - 在新窗口打开" data-zh="数据研发" data-en="Data Engineer">数据研发</a>
                 <a href="https://talent.antgroup.com/off-campus-position?positionId=25082706461865&tid=0b22831417587975758658512e57df" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="数据研发岗位详情 - 在新窗口打开" data-zh="查看详情" data-en="View Details">查看详情 →</a>
               </article>
               <article class="flex justify-between items-center py-1" role="listitem">
-                <a href="https://talent.antgroup.com/off-campus-position?positionId=25082706460510&tid=0b22831417587975758658512e57df" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="产品经理（数据产品、AI产品方向）岗位详情 - 在新窗口打开" data-zh="产品经理（数据产品、AI产品方向）" data-en="Product Manager (Data Products, AI Products Direction)">产品经理（数据产品、AI产品方向）</a>
+                <a href="https://talent.antgroup.com/off-campus-position?positionId=25082706460510&tid=0b22831417587975758658512e57df" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="产品经理（数据产品、AI产品方向）岗位详情 - 在新窗口打开" data-zh="产品经理（数据产品、AI产品方向）" data-en="Product Manager (AI & Data)">产品经理（数据产品、AI产品方向）</a>
                 <a href="https://talent.antgroup.com/off-campus-position?positionId=25082706460510&tid=0b22831417587975758658512e57df" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="产品经理（数据产品、AI产品方向）岗位详情 - 在新窗口打开" data-zh="查看详情" data-en="View Details">查看详情 →</a>
               </article>
             </div>


### PR DESCRIPTION
- 新增博客文章：智能编程助手 Neovate Code 正式开源 (云谦, 2025.09.24)
- 按 star 数量重新排序开源项目，新增 utoo、Neovate Code、WhiskerRAG
- 更新招聘岗位：
  * Node.js（前端 AI 基础设施方向）
  * 前端开发（AI技术产品方向）
  * 数据研发
  * 产品经理（数据产品、AI产品方向）
- 新增动态：Neovate Code 现已开源
- 保留原有博客文章：支付宝集福视觉盛宴背后的动效技术