### PR TITLE
feat: 实现牛皮纸配色主题

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -11,8 +11,8 @@
   --color-text: #5D4037;
   --color-text-light: #8D6E63;
   --color-text-lighter: #A1887F;
-  --color-border: #D7CCC8;
-  --color-border-dark: #BCAAA4;
+  --color-border: #C4A484;
+  --color-border-dark: #A68B5B;
   --color-background: #F4F1E8;
   --color-background-light: #F0EDE3;
   --color-background-accent: #EBE6D8;
@@ -223,7 +223,7 @@ blockquote div {
 /* 分隔线 */
 hr {
   border: none;
-  border-top: var(--border-width) solid var(--color-text-lighter);
+  border-top: var(--border-width) solid var(--color-border);
   margin: var(--spacing-md) 0;
   height: 0;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -5,17 +5,17 @@
 
 /* ===== 设计系统变量 ===== */
 :root {
-  /* 颜色系统 */
-  --color-primary: #000000;
-  --color-secondary: #333333;
-  --color-text: #111111;
-  --color-text-light: #666666;
-  --color-text-lighter: #999999;
-  --color-border: #e5e5e5;
-  --color-border-dark: #cccccc;
-  --color-background: #ffffff;
-  --color-background-light: #fafafa;
-  --color-background-accent: #f0f0f0;
+  /* 颜色系统 - 牛皮纸风格 */
+  --color-primary: #8B4513;
+  --color-secondary: #A0522D;
+  --color-text: #5D4037;
+  --color-text-light: #8D6E63;
+  --color-text-lighter: #A1887F;
+  --color-border: #D7CCC8;
+  --color-border-dark: #BCAAA4;
+  --color-background: #F4F1E8;
+  --color-background-light: #F0EDE3;
+  --color-background-accent: #EBE6D8;
   
   /* 字体系统 */
   --font-family-primary: serif;
@@ -58,6 +58,20 @@
   box-sizing: border-box;
 }
 
+/* 强制覆盖所有文字颜色为牛皮纸配色 */
+* {
+  color: var(--color-text) !important;
+}
+
+/* 特殊处理链接颜色 */
+a {
+  color: var(--color-text) !important;
+}
+
+a:hover {
+  color: var(--color-primary) !important;
+}
+
 html {
   scroll-behavior: smooth;
   font-size: 16px;
@@ -67,10 +81,19 @@ body {
   font-family: var(--font-family-primary);
   line-height: 1.15;
   color: var(--color-text);
-  background-color: var(--color-background);
+  background-color: var(--color-background) !important;
   letter-spacing: 0.01em;
   margin: 0;
   padding: 0;
+}
+
+/* 强制覆盖Tailwind CSS的背景色 */
+body.bg-white {
+  background-color: var(--color-background) !important;
+}
+
+html {
+  background-color: var(--color-background) !important;
 }
 
 /* ===== 排版系统 ===== */
@@ -130,6 +153,21 @@ a:focus {
 
 /* ===== 组件样式 ===== */
 
+/* Blockquote 组件 */
+blockquote {
+  background-color: var(--color-background-light) !important;
+  border-left-color: var(--color-text-lighter) !important;
+  color: var(--color-text) !important;
+}
+
+blockquote p {
+  color: var(--color-text) !important;
+}
+
+blockquote div {
+  color: var(--color-text-light) !important;
+}
+
 /* 跳过链接 */
 .skip-link {
   position: absolute;
@@ -180,17 +218,7 @@ a:focus {
   border-color: var(--color-text-light);
 }
 
-/* 引用块组件 */
-blockquote {
-  border-left: var(--border-width-thicker) solid var(--color-text-lighter);
-  padding-left: var(--spacing-md);
-  margin: var(--spacing-lg) 0;
-  font-style: italic;
-  color: var(--color-text);
-  background: var(--color-background-light);
-  padding: var(--spacing-md);
-  border-radius: 0 var(--border-radius) var(--border-radius) 0;
-}
+/* 引用块组件样式已移到上方统一处理 */
 
 /* 分隔线 */
 hr {
@@ -299,9 +327,10 @@ hr {
 .font-semibold { font-weight: 600; }
 .font-bold { font-weight: 700; }
 
-.text-black { color: var(--color-primary); }
+.text-black { color: var(--color-text); }
 .text-gray-600 { color: var(--color-text-light); }
 .text-gray-700 { color: var(--color-text); }
+.text-gray-900 { color: var(--color-text); }
 
 .tracking-wide { letter-spacing: 0.02em; }
 .tracking-tight { letter-spacing: -0.02em; }
@@ -321,7 +350,7 @@ hr {
 .border-gray-400 { border-color: var(--color-text-lighter); }
 
 /* ===== 背景工具类 ===== */
-.bg-white { background-color: var(--color-background); }
+.bg-white { background-color: var(--color-background) !important; }
 .bg-gray-50 { background-color: var(--color-background-light); }
 
 /* ===== 圆角工具类 ===== */
@@ -370,8 +399,8 @@ hr {
 
 /* ===== 选择文本样式 ===== */
 ::selection {
-  background: var(--color-background-accent);
-  color: var(--color-primary);
+  background: var(--color-border);
+  color: var(--color-text);
 }
 
 /* ===== 焦点样式 ===== */

--- a/css/style.css
+++ b/css/style.css
@@ -63,6 +63,11 @@
   color: var(--color-text) !important;
 }
 
+/* 强制覆盖所有边框颜色为棕色系 */
+* {
+  border-color: var(--color-border) !important;
+}
+
 /* 特殊处理链接颜色 */
 a {
   color: var(--color-text) !important;
@@ -344,10 +349,10 @@ hr {
 .border-l-2 { border-left: var(--border-width-thick) solid var(--color-border); }
 .border-l-4 { border-left: var(--border-width-thicker) solid var(--color-border); }
 
-.border-black { border-color: var(--color-primary); }
-.border-gray-200 { border-color: var(--color-border); }
-.border-gray-300 { border-color: var(--color-border-dark); }
-.border-gray-400 { border-color: var(--color-text-lighter); }
+.border-black { border-color: var(--color-border) !important; }
+.border-gray-200 { border-color: var(--color-border) !important; }
+.border-gray-300 { border-color: var(--color-border-dark) !important; }
+.border-gray-400 { border-color: var(--color-border) !important; }
 
 /* ===== 背景工具类 ===== */
 .bg-white { background-color: var(--color-background) !important; }

--- a/index.html
+++ b/index.html
@@ -388,14 +388,14 @@
                 <a href="https://talent.antgroup.com/off-campus-position?positionId=25082706460510&tid=0b22831417587975758658512e57df" target="_blank" class="text-sm text-gray-600 tracking-wide" aria-label="产品经理（数据产品、AI产品方向）岗位详情 - 在新窗口打开" data-zh="查看详情" data-en="View Details">查看详情 →</a>
               </article>
             </div>
-            <aside class="mt-2 p-2 bg-gray-50 border-l-2 border-gray-400">
+            <blockquote class="mt-2 p-2 bg-gray-50 border-l-2 border-gray-400">
               <p class="text-sm mb-1 tracking-wide" data-zh="欢迎投递简历。我们期待与优秀的你一起，引领体验科技，驱动数字生活。" data-en="We welcome your resume. We look forward to working with excellent talents like you to lead experience technology and drive digital life.">
                 欢迎投递简历，期待与优秀的你一起，引领体验科技，驱动数字生活。
               </p>
               <div class="text-sm text-gray-600 tracking-wide">
                 <div data-zh="" data-en="Work Locations: Hangzhou, Shanghai, Chengdu, Beijing">工作地点：杭州、上海、成都、北京</div>
               </div>
-            </aside>
+            </blockquote>
           </section>
 
           <!-- Culture Section -->


### PR DESCRIPTION
- 将网站配色方案改为素雅的牛皮纸风格
- 背景色改为淡黄色 (#F4F1E8)
- 文字颜色改为深棕色 (#5D4037)
- 修复所有文字颜色覆盖问题
- 统一aside为blockquote元素
- 确保所有组件使用一致的牛皮纸配色