### PR TITLE
feat: 招聘岗位更新为前端框架方向实习生

### DIFF
--- a/index.html
+++ b/index.html
@@ -491,7 +491,7 @@
                 点击岗位查看详情，欢迎投递简历，期待与优秀的你一起，引领体验科技，驱动数字生活。
               </p>
               <div class="text-sm text-gray-600 tracking-wide">
-                <div data-zh="" data-en="Location: Hangzhou">工作地点：杭州</div>
+                <div data-zh="工作地点：杭州" data-en="Location: Hangzhou">工作地点：杭州</div>
               </div>
             </aside>
           </section>

--- a/index.html
+++ b/index.html
@@ -483,7 +483,7 @@
             </h2>
             <div class="space-y-1" role="list">
               <article class="flex justify-between items-center py-1" role="listitem">
-                <a href="https://v2ex.com/t/1217346" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="前端框架方向实习生（2027 届）" data-zh="前端框架方向实习生（2027 届）" data-en="Frontend Framework Intern (2027)">前端框架方向实习生（2027 届）</a>
+                <a href="https://v2ex.com/t/1217346" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="前端工程师实习生（2027 届）" data-zh="前端工程师实习生（2027 届）" data-en="Frontend Engineer Intern (2027)">前端工程师实习生（2027 届）</a>
               </article>
             </div>
             <aside class="mt-2 p-2 bg-gray-50 border-l-2 border-gray-400">

--- a/index.html
+++ b/index.html
@@ -483,15 +483,15 @@
             </h2>
             <div class="space-y-1" role="list">
               <article class="flex justify-between items-center py-1" role="listitem">
-                <a href="https://talent.antgroup.com/off-campus-position?positionId=25111007544896" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="前端开发工程师（就业）" data-zh="前端开发工程师（就业）" data-en="Frontend Engineer">前端开发工程师（就业）</a>
+                <a href="https://v2ex.com/t/1217346" target="_blank" class="font-medium text-base tracking-wide hover:text-black" aria-label="前端框架方向实习生（2027 届）" data-zh="前端框架方向实习生（2027 届）" data-en="Frontend Framework Intern (2027)">前端框架方向实习生（2027 届）</a>
               </article>
             </div>
             <aside class="mt-2 p-2 bg-gray-50 border-l-2 border-gray-400">
-              <p class="text-sm mb-1 tracking-wide" data-zh="欢迎投递简历。我们期待与优秀的你一起，引领体验科技，驱动数字生活。" data-en="We welcome your resume. We look forward to working with excellent talents like you to lead experience technology and drive digital life.">
-                欢迎投递简历，期待与优秀的你一起，引领体验科技，驱动数字生活。
+              <p class="text-sm mb-1 tracking-wide" data-zh="点击岗位查看详情，欢迎投递简历，期待与优秀的你一起，引领体验科技，驱动数字生活。" data-en="Click the position for details. We welcome your resume and look forward to working with excellent talents like you.">
+                点击岗位查看详情，欢迎投递简历，期待与优秀的你一起，引领体验科技，驱动数字生活。
               </p>
               <div class="text-sm text-gray-600 tracking-wide">
-                <div data-zh="" data-en="Work Locations: Hangzhou, Shanghai, Chengdu, Beijing">工作地点：杭州、上海、成都、北京</div>
+                <div data-zh="" data-en="Location: Hangzhou">工作地点：杭州</div>
               </div>
             </aside>
           </section>


### PR DESCRIPTION
## 改动

将首页「待招聘岗位」更新为前端框架方向实习生（2027 届），岗位链接指向 V2EX 招聘帖（https://v2ex.com/t/1217346）。

- 岗位名:前端开发工程师（就业）→ 前端框架方向实习生（2027 届）
- 页面只展示岗位名 + 链接，详情引导用户点击过去看
- 工作地点:杭州、上海、成都、北京 → 杭州
- 中英文双语文案同步更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)