### PR TITLE
feat: 引入 surge-preview 实现 PR 网站预览

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,17 @@
+name: 🔂 Surge PR Preview
+on:
+  pull_request:
+    types: [opened, synchronize, closed]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: afc163/surge-preview@v2
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN }}
+          dist: .
+          teardown: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,5 +13,6 @@ jobs:
       - uses: afc163/surge-preview@v1
         with:
           surge_token: ${{ secrets.SURGE_TOKEN }}
+          build: echo "no build needed"
           dist: .
           teardown: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,8 +9,8 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: afc163/surge-preview@v2
+      - uses: actions/checkout@v6
+      - uses: afc163/surge-preview@v1
         with:
           surge_token: ${{ secrets.SURGE_TOKEN }}
           dist: .


### PR DESCRIPTION
## 背景

每个 PR 合并前需要能够预览网站效果，目前项目没有任何 CI/CD 预览能力。

## 变更

添加 `.github/workflows/preview.yml`，使用 [afc163/surge-preview](https://github.com/afc163/surge-preview) GitHub Action：

- PR 打开/更新时自动部署到 surge.sh，并在 PR 评论中附带预览链接
- PR 关闭时自动清理 surge 预览（`teardown: true`）
- 纯静态站点无构建步骤，`dist: .` 直接部署根目录

## 前置条件

需要在仓库 Settings → Secrets 中添加 `SURGE_TOKEN`，获取方式：

```bash
npx surge token
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated PR preview deployments using a GitHub Actions workflow that builds/displays the latest changes and automatically tears down the preview when the PR is closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->