### PR TITLE
更新动态和 GitHub stars 兜底值

### DIFF
--- a/css/giscus-theme.css
+++ b/css/giscus-theme.css
@@ -3,7 +3,7 @@
  * 配色与字体对齐 css/style.css 的设计系统变量，使评论区与页面风格一致
  */
 
-/* biome-ignore-all lint/complexity/noImportantStyles: 覆盖 giscus iframe 内置 Tailwind 工具类样式必须用 !important */
+/* biome-ignore-all lint/nursery/noImportantStyles: 覆盖 giscus iframe 内置 Tailwind 工具类样式必须用 !important */
 
 main {
   /* 语法高亮（代码块）保留原 light 主题配色，仅微调以贴合暖色基底 */

--- a/css/style.css
+++ b/css/style.css
@@ -188,12 +188,12 @@ a:focus {
 /* 引用块组件 */
 blockquote {
   border-left: var(--border-width-thicker) solid var(--color-text-lighter);
-  padding-left: var(--spacing-md);
   margin: var(--spacing-lg) 0;
   font-style: italic;
   color: var(--color-text);
   background: var(--color-background-light);
   padding: var(--spacing-md);
+  padding-left: var(--spacing-md);
   border-radius: 0 var(--border-radius) var(--border-radius) 0;
 }
 

--- a/index.html
+++ b/index.html
@@ -99,6 +99,17 @@
                 <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2026-06">2026-06</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
+                    <a href="https://mp.weixin.qq.com/s/yOFT96DQWWiKk8OvLSoOgg" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="智能体记忆项目 Hebb Mind：仿照大脑记忆机制，给 AI 装了一个海马体 - 在新窗口打开" data-zh="智能体记忆项目 Hebb Mind：仿照大脑记忆机制，给 AI 装了一个海马体" data-en="Hebb Mind: An agent memory project that brings brain-inspired memory mechanisms to AI">智能体记忆项目 Hebb Mind：仿照大脑记忆机制，给 AI 装了一个海马体</a>
+                  </h3>
+                  <p class="text-sm tracking-wide" data-zh="Hebb Mind 为 AI Agent 提供编码、回放、整合、遗忘的长期记忆循环，支持本地优先部署、REST/MCP 接入、混合检索和动态遗忘。" data-en="Hebb Mind gives AI agents a long-term memory loop for encoding, replay, consolidation, and forgetting, with local-first deployment, REST/MCP integration, hybrid search, and dynamic forgetting.">
+                    Hebb Mind 为 AI Agent 提供编码、回放、整合、遗忘的长期记忆循环，支持本地优先部署、REST/MCP 接入、混合检索和动态遗忘。
+                  </p>
+                </div>
+              </article>
+              <article class="flex items-start" role="listitem">
+                <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2026-06">2026-06</time>
+                <div>
+                  <h3 class="font-semibold text-base mb-1 tracking-wide">
                     <a href="https://mp.weixin.qq.com/s/X_Tmmpvl-vhoeFlFsn6bDg" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="@utoo/pack：基于 Turbopack 的下一代构建工具 - 在新窗口打开" data-zh="@utoo/pack：基于 Turbopack 的下一代构建工具" data-en="@utoo/pack: Next-generation build tool based on Turbopack">@utoo/pack：基于 Turbopack 的下一代构建工具</a>
                   </h3>
                   <p class="text-sm tracking-wide" data-zh="utoopack 是 Utoo 工具链中负责前端构建的工具，基于 Turbopack 打造下一代构建能力。" data-en="utoopack is the frontend build tool in the Utoo toolchain, delivering next-generation build capabilities based on Turbopack.">
@@ -511,14 +522,14 @@
               部门文化
             </h2>
             <blockquote class="mb-2 p-2 bg-gray-50 border-l-2 border-gray-400">
-              <p class="text-sm text-gray-700 tracking-wide" data-zh="是体验技术部的核心文化，它们的背后是"专业、责任、行动"。" data-en="is the core culture of the Experience Technology Department. Behind them are 'Professional, Responsible, Action'.">
+              <p class="text-sm text-gray-700 tracking-wide" data-zh="是体验技术部的核心文化，它们的背后是&quot;专业、责任、行动&quot;。" data-en="is the core culture of the Experience Technology Department. Behind them are 'Professional, Responsible, Action'.">
                 "简单、自由、有爱" 是体验技术部的核心文化，它们的背后是 "专业、责任、行动"。
               </p>
             </blockquote>
             <div class="space-y-1">
               <article>
                 <h3 class="font-semibold text-base mb-1 tracking-wide" data-zh="简单 —— 心态与技术上的极简" data-en="Simple — Minimalism in Mindset and Technology">简单 —— 心态与技术上的极简</h3>
-                <p class="text-xs leading-tight tracking-wide" data-zh="团队追求「保持简单」，不仅是做技术保持简单性，也包括心态上的纯粹：不攀比、不畏惧职场鄙视链，只专注于进入心流状态的那份热爱与专业。在讨论中坚持"用专业说话"，任何观点都可据理力争，让复杂的问题回归本质。" data-en="The team pursues 'keeping it simple', not only maintaining simplicity in technology, but also purity in mindset: no comparison, no fear of workplace hierarchy, only focusing on the passion and professionalism that enters the flow state. In discussions, we insist on 'speaking with professionalism', any viewpoint can be argued with reason, letting complex problems return to their essence.">
+                <p class="text-xs leading-tight tracking-wide" data-zh="团队追求「保持简单」，不仅是做技术保持简单性，也包括心态上的纯粹：不攀比、不畏惧职场鄙视链，只专注于进入心流状态的那份热爱与专业。在讨论中坚持&quot;用专业说话&quot;，任何观点都可据理力争，让复杂的问题回归本质。" data-en="The team pursues 'keeping it simple', not only maintaining simplicity in technology, but also purity in mindset: no comparison, no fear of workplace hierarchy, only focusing on the passion and professionalism that enters the flow state. In discussions, we insist on 'speaking with professionalism', any viewpoint can be argued with reason, letting complex problems return to their essence.">
                   团队追求「保持简单」，不仅是做技术保持简单性，也包括心态上的纯粹：不攀比、不畏惧职场鄙视链，只专注于进入心流状态的那份热爱与专业。在讨论中坚持"用专业说话"，任何观点都可据理力争，让复杂的问题回归本质。
                 </p>
               </article>
@@ -530,7 +541,7 @@
               </article>
               <article>
                 <h3 class="font-semibold text-base mb-1 tracking-wide" data-zh="有爱 —— 关心、行动并致力于真正触达影响" data-en="Loving — Caring, Acting and Committed to Truly Reaching Impact">有爱 —— 关心、行动并致力于真正触达影响</h3>
-                <p class="text-xs leading-tight tracking-wide" data-zh="有爱不仅是情感表达，更体现在关心他人、用心做事、静心积累的行为里。团队强调公益行动与实际行动一致："光说不做不行"，细致践行每一份社会责任，让"有爱"成为专业和行动力的结合体。" data-en="Love is not only emotional expression, but also reflected in the behavior of caring for others, doing things with heart, and accumulating quietly. The team emphasizes that public welfare actions are consistent with actual actions: 'Talking without doing is not enough', carefully practicing every social responsibility, making 'love' a combination of professionalism and action.">
+                <p class="text-xs leading-tight tracking-wide" data-zh="有爱不仅是情感表达，更体现在关心他人、用心做事、静心积累的行为里。团队强调公益行动与实际行动一致：&quot;光说不做不行&quot;，细致践行每一份社会责任，让&quot;有爱&quot;成为专业和行动力的结合体。" data-en="Love is not only emotional expression, but also reflected in the behavior of caring for others, doing things with heart, and accumulating quietly. The team emphasizes that public welfare actions are consistent with actual actions: 'Talking without doing is not enough', carefully practicing every social responsibility, making 'love' a combination of professionalism and action.">
                   有爱不仅是情感表达，更体现在关心他人、用心做事、静心积累的行为里。团队强调公益行动与实际行动一致："光说不做不行"，细致践行每一份社会责任，让"有爱"成为专业和行动力的结合体。
                 </p>
               </article>

--- a/js/stars.js
+++ b/js/stars.js
@@ -15,22 +15,22 @@
 
   // 写死兜底值：API 限流或失败时使用。数值会随时间略有偏差，定期更新即可。
   const FALLBACK = {
-    'ant-design': 192115,
-    'eggjs/egg': 18993,
-    'umijs/qiankun': 16621,
-    'umijs/umi': 16037,
-    'umijs/dumi': 3797,
-    'neovateai/neovate-code': 1546,
-    'afx-team/petercat': 1491,
-    'utooland/utoo': 2513,
+    'ant-design': 192728,
+    'eggjs/egg': 18995,
+    'umijs/qiankun': 16624,
+    'umijs/umi': 16035,
+    'umijs/dumi': 3796,
+    'neovateai/neovate-code': 1548,
+    'afx-team/petercat': 1492,
+    'utooland/utoo': 2515,
     'cnpm/cnpm': 2096,
     'galacean/effects-runtime': 610,
-    'afx-team/UI-UG': 87,
+    'afx-team/UI-UG': 88,
     'unieojs/unieo': 32,
     'afx-team/evjs': 20,
     'afx-team/WhiskerRAG': 11,
-    'afx-team/hebb-mind': 32,
-    'afx-team/UI-UX': 9,
+    'afx-team/hebb-mind': 35,
+    'afx-team/UI-UX': 21,
   };
 
   /** 从卡片内的 GitHub 链接解析出 owner/repo，或组织名（组织主页链接） */


### PR DESCRIPTION
## Summary

- add the Hebb Mind 2026-06 WeChat article to Latest News
- refresh GitHub star fallback counts, including Hebb Mind and UI-UX
- fix small existing Biome lint blockers in CSS and HTML attributes so lint can run cleanly

## Verification

- `npm run lint:check`
- `node --check js/stars.js`
- `git diff --check`

## Notes

- `npm run format:check` still reports broad existing formatting changes for `index.html` and `css/style.css`; this PR intentionally avoids a full-file formatting churn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Hebb Mind” entry to the latest updates/news list.
  * Refreshed GitHub star fallback values, which may affect star badges and ordering when live counts aren’t available.
* **Bug Fixes**
  * Improved text rendering in the culture section by standardizing quotation formatting (escaped quotes) for better consistency.
* **Style**
  * Made a small spacing adjustment to blockquote styling for more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->