### PR TITLE
fix: localize external link aria labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
                 <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2026-06">2026-06</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
-                    <a href="https://github.com/afx-team/UI-UX" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="UI-UX：面向移动端 UX 缺陷诊断的多模态大模型（CVPR 2026 Findings） - 在新窗口打开" data-zh="UI-UX：面向移动端 UX 缺陷诊断的多模态大模型（CVPR 2026 Findings）" data-en="UI-UX: Multimodal LLM for Mobile UX Defect Diagnosis (CVPR 2026 Findings)">UI-UX：面向移动端 UX 缺陷诊断的多模态大模型（CVPR 2026 Findings）</a>
+                    <a href="https://github.com/afx-team/UI-UX" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="UI-UX：面向移动端 UX 缺陷诊断的多模态大模型（CVPR 2026 Findings） - 在新窗口打开" data-aria-zh="UI-UX：面向移动端 UX 缺陷诊断的多模态大模型（CVPR 2026 Findings） - 在新窗口打开" data-aria-en="UI-UX: Multimodal LLM for Mobile UX Defect Diagnosis (CVPR 2026 Findings) - Open in new window" data-zh="UI-UX：面向移动端 UX 缺陷诊断的多模态大模型（CVPR 2026 Findings）" data-en="UI-UX: Multimodal LLM for Mobile UX Defect Diagnosis (CVPR 2026 Findings)">UI-UX：面向移动端 UX 缺陷诊断的多模态大模型（CVPR 2026 Findings）</a>
                   </h3>
                   <p class="text-sm tracking-wide" data-zh="蚂蚁集团发布 UI-UX，面向移动端 UX 缺陷诊断的 4B 多模态大模型，并提出首个 UX 推理视觉语言基准 UXBench，在 UXBench 上以 79.63% 的准确率超越 Claude-4.5-Sonnet 等前沿模型。" data-en="Ant Group releases UI-UX, a 4B multimodal LLM for mobile UX defect diagnosis, and introduces UXBench — the first vision–language benchmark for UX reasoning. UI-UX achieves 79.63% accuracy on UXBench, surpassing Claude-4.5-Sonnet and other frontier models.">
                     蚂蚁集团发布 UI-UX，面向移动端 UX 缺陷诊断的 4B 多模态大模型，并提出首个 UX 推理视觉语言基准 UXBench，在 UXBench 上以 79.63% 的准确率超越 Claude-4.5-Sonnet 等前沿模型。
@@ -99,7 +99,7 @@
                 <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2026-06">2026-06</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
-                    <a href="https://mp.weixin.qq.com/s/yOFT96DQWWiKk8OvLSoOgg" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="智能体记忆项目 Hebb Mind：仿照大脑记忆机制，给 AI 装了一个海马体 - 在新窗口打开" data-zh="智能体记忆项目 Hebb Mind：仿照大脑记忆机制，给 AI 装了一个海马体" data-en="Hebb Mind: An agent memory project that brings brain-inspired memory mechanisms to AI">智能体记忆项目 Hebb Mind：仿照大脑记忆机制，给 AI 装了一个海马体</a>
+                    <a href="https://mp.weixin.qq.com/s/yOFT96DQWWiKk8OvLSoOgg" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="智能体记忆项目 Hebb Mind：仿照大脑记忆机制，给 AI 装了一个海马体 - 在新窗口打开" data-aria-zh="智能体记忆项目 Hebb Mind：仿照大脑记忆机制，给 AI 装了一个海马体 - 在新窗口打开" data-aria-en="Hebb Mind: An agent memory project that brings brain-inspired memory mechanisms to AI - Open in new window" data-zh="智能体记忆项目 Hebb Mind：仿照大脑记忆机制，给 AI 装了一个海马体" data-en="Hebb Mind: An agent memory project that brings brain-inspired memory mechanisms to AI">智能体记忆项目 Hebb Mind：仿照大脑记忆机制，给 AI 装了一个海马体</a>
                   </h3>
                   <p class="text-sm tracking-wide" data-zh="Hebb Mind 为 AI Agent 提供编码、回放、整合、遗忘的长期记忆循环，支持本地优先部署、REST/MCP 接入、混合检索和动态遗忘。" data-en="Hebb Mind gives AI agents a long-term memory loop for encoding, replay, consolidation, and forgetting, with local-first deployment, REST/MCP integration, hybrid search, and dynamic forgetting.">
                     Hebb Mind 为 AI Agent 提供编码、回放、整合、遗忘的长期记忆循环，支持本地优先部署、REST/MCP 接入、混合检索和动态遗忘。
@@ -110,7 +110,7 @@
                 <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2026-06">2026-06</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
-                    <a href="https://mp.weixin.qq.com/s/X_Tmmpvl-vhoeFlFsn6bDg" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="@utoo/pack：基于 Turbopack 的下一代构建工具 - 在新窗口打开" data-zh="@utoo/pack：基于 Turbopack 的下一代构建工具" data-en="@utoo/pack: Next-generation build tool based on Turbopack">@utoo/pack：基于 Turbopack 的下一代构建工具</a>
+                    <a href="https://mp.weixin.qq.com/s/X_Tmmpvl-vhoeFlFsn6bDg" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="@utoo/pack：基于 Turbopack 的下一代构建工具 - 在新窗口打开" data-aria-zh="@utoo/pack：基于 Turbopack 的下一代构建工具 - 在新窗口打开" data-aria-en="@utoo/pack: Next-generation build tool based on Turbopack - Open in new window" data-zh="@utoo/pack：基于 Turbopack 的下一代构建工具" data-en="@utoo/pack: Next-generation build tool based on Turbopack">@utoo/pack：基于 Turbopack 的下一代构建工具</a>
                   </h3>
                   <p class="text-sm tracking-wide" data-zh="utoopack 是 Utoo 工具链中负责前端构建的工具，基于 Turbopack 打造下一代构建能力。" data-en="utoopack is the frontend build tool in the Utoo toolchain, delivering next-generation build capabilities based on Turbopack.">
                     utoopack 是 Utoo 工具链中负责前端构建的工具，基于 Turbopack 打造下一代构建能力。
@@ -121,7 +121,7 @@
                 <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2026-05">2026-05</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
-                    <a href="https://mp.weixin.qq.com/s/IftwWGwBmUqHG4V7FpaxyA" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="Ant Design Pro v6.0.0 发布，全面拥抱最新技术栈 - 在新窗口打开" data-zh="Ant Design Pro v6.0.0 发布，全面拥抱最新技术栈" data-en="Ant Design Pro v6.0.0 released, fully embracing the latest tech stack">Ant Design Pro v6.0.0 发布，全面拥抱最新技术栈</a>
+                    <a href="https://mp.weixin.qq.com/s/IftwWGwBmUqHG4V7FpaxyA" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="Ant Design Pro v6.0.0 发布，全面拥抱最新技术栈 - 在新窗口打开" data-aria-zh="Ant Design Pro v6.0.0 发布，全面拥抱最新技术栈 - 在新窗口打开" data-aria-en="Ant Design Pro v6.0.0 released, fully embracing the latest tech stack - Open in new window" data-zh="Ant Design Pro v6.0.0 发布，全面拥抱最新技术栈" data-en="Ant Design Pro v6.0.0 released, fully embracing the latest tech stack">Ant Design Pro v6.0.0 发布，全面拥抱最新技术栈</a>
                   </h3>
                   <p class="text-sm tracking-wide" data-zh="Ant Design Pro v6.0.0 大版本升级，涉及框架和依赖的全面更新，全面拥抱最新技术栈。" data-en="Ant Design Pro v6.0.0 major release, with comprehensive updates to the framework and dependencies, fully embracing the latest tech stack.">
                     Ant Design Pro v6.0.0 大版本升级，涉及框架和依赖的全面更新，全面拥抱最新技术栈。
@@ -132,7 +132,7 @@
                 <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2026-04">2026-04</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
-                    <a href="https://mp.weixin.qq.com/s/8uRL7NFMkuuG2nCdDselzA" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="utoo：新一代基于 Rust 的 npm 包管理器 - 在新窗口打开" data-zh="utoo：新一代基于 Rust 的 npm 包管理器" data-en="utoo: A next-generation Rust-based npm package manager">utoo：新一代基于 Rust 的 npm 包管理器</a>
+                    <a href="https://mp.weixin.qq.com/s/8uRL7NFMkuuG2nCdDselzA" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="utoo：新一代基于 Rust 的 npm 包管理器 - 在新窗口打开" data-aria-zh="utoo：新一代基于 Rust 的 npm 包管理器 - 在新窗口打开" data-aria-en="utoo: A next-generation Rust-based npm package manager - Open in new window" data-zh="utoo：新一代基于 Rust 的 npm 包管理器" data-en="utoo: A next-generation Rust-based npm package manager">utoo：新一代基于 Rust 的 npm 包管理器</a>
                   </h3>
                   <p class="text-sm tracking-wide" data-zh="详述团队基于 Rust 重新构建 npm 包管理器 utoo 的技术动机、架构设计与核心实现，并与社区主流方案深入对比。" data-en="A deep dive into the team's motivation, architecture, and core implementation of rebuilding the npm package manager utoo in Rust, with in-depth comparisons against mainstream community solutions.">
                     详述团队基于 Rust 重新构建 npm 包管理器 utoo 的技术动机、架构设计与核心实现，并与社区主流方案深入对比。
@@ -143,7 +143,7 @@
                 <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2025-12">2025-12</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
-                    <a href="https://mp.weixin.qq.com/s/kY3qX7D5HeBUUeQAi8g5cw" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="Ant Design 发布 Markdown 渲染器 X-Markdown - 在新窗口打开" data-zh="Ant Design 发布 Markdown 渲染器 X-Markdown" data-en="Ant Design releases Markdown renderer X-Markdown">Ant Design 发布 Markdown 渲染器 X-Markdown</a>
+                    <a href="https://mp.weixin.qq.com/s/kY3qX7D5HeBUUeQAi8g5cw" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="Ant Design 发布 Markdown 渲染器 X-Markdown - 在新窗口打开" data-aria-zh="Ant Design 发布 Markdown 渲染器 X-Markdown - 在新窗口打开" data-aria-en="Ant Design releases Markdown renderer X-Markdown - Open in new window" data-zh="Ant Design 发布 Markdown 渲染器 X-Markdown" data-en="Ant Design releases Markdown renderer X-Markdown">Ant Design 发布 Markdown 渲染器 X-Markdown</a>
                   </h3>
                   <p class="text-sm tracking-wide" data-zh="Ant Design 发布 Markdown 渲染器 X-Markdown，专为 AI 流式对话打造，高性能、流式友好、插件开箱即用。" data-en="Ant Design releases Markdown renderer X-Markdown, designed for AI streaming conversations, high performance, stream-friendly, and plugins out of the box.">
                     Ant Design 发布 Markdown 渲染器 X-Markdown，专为 AI 流式对话打造，高性能、流式友好、插件开箱即用。
@@ -154,7 +154,7 @@
                 <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2025-12">2025-12</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
-                    <a href="https://mp.weixin.qq.com/s/Umj-FyNus8hqK53DgHhVvg" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="SEE Conf 2025 精彩回顾来啦！附 PPT 及视频 - 在新窗口打开" data-zh="SEE Conf 2025 精彩回顾来啦！附 PPT 及视频" data-en="SEE Conf 2025 Highlights! With PPT and Videos">SEE Conf 2025 精彩回顾来啦！附 PPT 及视频</a>
+                    <a href="https://mp.weixin.qq.com/s/Umj-FyNus8hqK53DgHhVvg" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="SEE Conf 2025 精彩回顾来啦！附 PPT 及视频 - 在新窗口打开" data-aria-zh="SEE Conf 2025 精彩回顾来啦！附 PPT 及视频 - 在新窗口打开" data-aria-en="SEE Conf 2025 Highlights! With PPT and Videos - Open in new window" data-zh="SEE Conf 2025 精彩回顾来啦！附 PPT 及视频" data-en="SEE Conf 2025 Highlights! With PPT and Videos">SEE Conf 2025 精彩回顾来啦！附 PPT 及视频</a>
                   </h3>
                   <p class="text-sm tracking-wide" data-zh="SEE Conf 2025 蚂蚁终端体验科技大会精彩回顾，包含主会场及 5 大专场，47 位演讲嘉宾分享 AI Coding、基础前端、互动及可视化等前沿技术。" data-en="SEE Conf 2025 Ant Terminal Experience Technology Conference highlights, including the main venue and 5 major sessions, with 47 speakers sharing cutting-edge technologies such as AI Coding, basic frontend, interaction and visualization.">
                     SEE Conf 2025 蚂蚁终端体验科技大会精彩回顾，包含主会场及 5 大专场，47 位演讲嘉宾分享 AI Coding、基础前端、互动及可视化等前沿技术。
@@ -165,7 +165,7 @@
                 <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2025-11">2025-11</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
-                    <a href="https://mp.weixin.qq.com/s/-7oyspesOl59_ceJc_04Uw" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="Ant Design 6.0 & Ant Design X 2.0 在 SEE Conf 2025 发布 - 在新窗口打开" data-zh="Ant Design 6.0 & Ant Design X 2.0 在 SEE Conf 2025 发布" data-en="Ant Design 6.0 & Ant Design X 2.0 Released at SEE Conf 2025">Ant Design 6.0 & Ant Design X 2.0 在 SEE Conf 2025 发布</a>
+                    <a href="https://mp.weixin.qq.com/s/-7oyspesOl59_ceJc_04Uw" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="Ant Design 6.0 & Ant Design X 2.0 在 SEE Conf 2025 发布 - 在新窗口打开" data-aria-zh="Ant Design 6.0 & Ant Design X 2.0 在 SEE Conf 2025 发布 - 在新窗口打开" data-aria-en="Ant Design 6.0 & Ant Design X 2.0 Released at SEE Conf 2025 - Open in new window" data-zh="Ant Design 6.0 & Ant Design X 2.0 在 SEE Conf 2025 发布" data-en="Ant Design 6.0 & Ant Design X 2.0 Released at SEE Conf 2025">Ant Design 6.0 & Ant Design X 2.0 在 SEE Conf 2025 发布</a>
                   </h3>
                   <p class="text-sm tracking-wide" data-zh="Ant Design 6.0 & Ant Design X 2.0 正式发布，带来 React 18+ 支持、纯 CSS Variables 样式架构、全量组件语义化结构等重大更新。" data-en="Ant Design 6.0 & Ant Design X 2.0 officially released, bringing major updates such as React 18+ support, pure CSS Variables style architecture, and full component semantic structure.">
                     Ant Design 6.0 & Ant Design X 2.0 正式发布，带来 React 18+ 支持、纯 CSS Variables 样式架构、全量组件语义化结构等重大更新。
@@ -176,7 +176,7 @@
                 <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2025-10">2025-10</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
-                    <a href="https://seeconf.antgroup.com/" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="SEE Conf 2025 回来了 - 在新窗口打开" data-zh="SEE Conf 2025 回来了" data-en="SEE Conf 2025 is Back">SEE Conf 2025 回来了</a>
+                    <a href="https://seeconf.antgroup.com/" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="SEE Conf 2025 回来了 - 在新窗口打开" data-aria-zh="SEE Conf 2025 回来了 - 在新窗口打开" data-aria-en="SEE Conf 2025 is Back - Open in new window" data-zh="SEE Conf 2025 回来了" data-en="SEE Conf 2025 is Back">SEE Conf 2025 回来了</a>
                   </h3>
                   <p class="text-sm tracking-wide" data-zh="SEE 是 Seeking Experience & Engineering 的缩写，意为探索用户体验与工程实践。我们期待与业界同行共同分享和交流体验科技的最新进展，探讨切磋 AI 时代体验科技的未来发展。" data-en="SEE stands for Seeking Experience & Engineering, meaning exploring user experience and engineering practices. We look forward to sharing and exchanging the latest developments in experience technology with industry peers, discussing the future development of experience technology in the AI era.">
                     SEE 是 Seeking Experience & Engineering 的缩写，意为探索用户体验与工程实践。我们期待与业界同行共同分享和交流体验科技的最新进展，探讨切磋 AI 时代体验科技的未来发展。
@@ -187,7 +187,7 @@
                 <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2025-10">2025-10</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
-                    <a href="https://mp.weixin.qq.com/s/HEIGI79hiqJz3uCcOOn_6A" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="UI-UG：首个统一UI理解与生成的大模型正式开源 - 在新窗口打开" data-zh="UI-UG：首个统一UI理解与生成的大模型正式开源" data-en="UI-UG: First Unified UI Understanding and Generation Model Open Sourced">UI-UG：首个统一UI理解与生成的大模型正式开源</a>
+                    <a href="https://mp.weixin.qq.com/s/HEIGI79hiqJz3uCcOOn_6A" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="UI-UG：首个统一UI理解与生成的大模型正式开源 - 在新窗口打开" data-aria-zh="UI-UG：首个统一UI理解与生成的大模型正式开源 - 在新窗口打开" data-aria-en="UI-UG: First Unified UI Understanding and Generation Model Open Sourced - Open in new window" data-zh="UI-UG：首个统一UI理解与生成的大模型正式开源" data-en="UI-UG: First Unified UI Understanding and Generation Model Open Sourced">UI-UG：首个统一UI理解与生成的大模型正式开源</a>
                   </h3>
                   <p class="text-sm tracking-wide" data-zh="支付宝体验技术部正式发布并开源首个将 UI 理解与 UI 生成两大核心能力统一起来的 UI 领域垂类多模态大模型 UI-UG，在理解和生成场景中均展现卓越性能，多模态任务准确率达 SOTA。" data-en="Alipay Experience Technology Department officially released and open-sourced UI-UG, the first vertical multimodal large model in the UI field that unifies UI understanding and UI generation capabilities, demonstrating excellent performance in both understanding and generation scenarios with SOTA accuracy in multimodal tasks.">
                     支付宝体验技术部正式发布并开源首个将 UI 理解与 UI 生成两大核心能力统一起来的 UI 领域垂类多模态大模型 UI-UG，在理解和生成场景中均展现卓越性能，多模态任务准确率达 SOTA。
@@ -198,7 +198,7 @@
                 <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2025-09">2025-09</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
-                    <a href="https://neovateai.dev/zh-CN/blog/neovate-code-is-open-sourced/" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="Neovate Code 现已开源 - 在新窗口打开" data-zh="Neovate Code 现已开源" data-en="Neovate Code is Now Open Source">Neovate Code 现已开源</a>
+                    <a href="https://neovateai.dev/zh-CN/blog/neovate-code-is-open-sourced/" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="Neovate Code 现已开源 - 在新窗口打开" data-aria-zh="Neovate Code 现已开源 - 在新窗口打开" data-aria-en="Neovate Code is Now Open Source - Open in new window" data-zh="Neovate Code 现已开源" data-en="Neovate Code is Now Open Source">Neovate Code 现已开源</a>
                   </h3>
                   <p class="text-sm tracking-wide" data-zh="AI 驱动的编程助手 Neovate Code 正式开源，提供代码生成、错误修复、代码审查等功能，支持交互模式和无头模式。" data-en="AI-driven programming assistant Neovate Code is officially open source, providing code generation, bug fixes, code review and other features, supporting interactive and headless modes.">
                     AI 驱动的编程助手 Neovate Code 正式开源，提供代码生成、错误修复、代码审查等功能，支持交互模式和无头模式。
@@ -209,7 +209,7 @@
                 <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2025-09">2025-09</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
-                    <a href="https://mp.weixin.qq.com/s/vRlkkQGhIxGJAD4EYshflw" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="智能编程助手 Neovate Code 正式开源 - 在新窗口打开" data-zh="智能编程助手 Neovate Code 正式开源" data-en="Intelligent Programming Assistant Neovate Code is Officially Open Source">智能编程助手 Neovate Code 正式开源</a>
+                    <a href="https://mp.weixin.qq.com/s/vRlkkQGhIxGJAD4EYshflw" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="智能编程助手 Neovate Code 正式开源 - 在新窗口打开" data-aria-zh="智能编程助手 Neovate Code 正式开源 - 在新窗口打开" data-aria-en="Intelligent Programming Assistant Neovate Code is Officially Open Source - Open in new window" data-zh="智能编程助手 Neovate Code 正式开源" data-en="Intelligent Programming Assistant Neovate Code is Officially Open Source">智能编程助手 Neovate Code 正式开源</a>
                   </h3>
                   <p class="text-sm tracking-wide" data-zh="云谦 · 智能编程助手 Neovate Code 正式开源，深入解读其设计理念与核心能力。" data-en="Yun Qian · Intelligent programming assistant Neovate Code is officially open source, with an in-depth look at its design philosophy and core capabilities.">
                     云谦 · 智能编程助手 Neovate Code 正式开源，深入解读其设计理念与核心能力。
@@ -220,7 +220,7 @@
                 <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2025-07">2025-07</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
-                    <a href="https://mp.weixin.qq.com/s/CdCvCzfycme6rw4OKa_1aA" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="MCP 在蚂蚁前端的落地之旅 - 在新窗口打开" data-zh="MCP 在蚂蚁前端的落地之旅" data-en="MCP Landing Journey in Ant Frontend">MCP 在蚂蚁前端的落地之旅</a>
+                    <a href="https://mp.weixin.qq.com/s/CdCvCzfycme6rw4OKa_1aA" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="MCP 在蚂蚁前端的落地之旅 - 在新窗口打开" data-aria-zh="MCP 在蚂蚁前端的落地之旅 - 在新窗口打开" data-aria-en="MCP Landing Journey in Ant Frontend - Open in new window" data-zh="MCP 在蚂蚁前端的落地之旅" data-en="MCP Landing Journey in Ant Frontend">MCP 在蚂蚁前端的落地之旅</a>
                   </h3>
                   <p class="text-sm tracking-wide" data-zh="顾珠彬(零弌) · 分享 MCP（Model Context Protocol）在蚂蚁前端的落地实践与经验。" data-en="Gu Zhubin (Ling Yi) · Sharing the practical implementation and experience of MCP (Model Context Protocol) in Ant frontend.">
                     顾珠彬(零弌) · 分享 MCP（Model Context Protocol）在蚂蚁前端的落地实践与经验。
@@ -231,7 +231,7 @@
                 <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2025-04">2025-04</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
-                    <a href="https://github.com/umijs/mako/issues/1872" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="Mako Next: A new bundler on top of Turbopack - 在新窗口打开" data-zh="[Mako Next]: A new bundler on top of Turbopack" data-en="[Mako Next]: A new bundler on top of Turbopack">[Mako Next]: A new bundler on top of Turbopack</a>
+                    <a href="https://github.com/umijs/mako/issues/1872" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="Mako Next: A new bundler on top of Turbopack - 在新窗口打开" data-aria-zh="Mako Next: A new bundler on top of Turbopack - 在新窗口打开" data-aria-en="[Mako Next]: A new bundler on top of Turbopack - Open in new window" data-zh="[Mako Next]: A new bundler on top of Turbopack" data-en="[Mako Next]: A new bundler on top of Turbopack">[Mako Next]: A new bundler on top of Turbopack</a>
                   </h3>
                   <p class="text-sm tracking-wide" data-zh="发布基于 Turbopack 的新打包器 utoopack，将替代原有的 Mako 打包器，提供更快的构建性能和更完整的 Webpack 兼容性。" data-en="Release of utoopack, a new bundler based on Turbopack, which will replace the original Mako bundler, providing faster build performance and more complete Webpack compatibility.">
                     发布基于 Turbopack 的新打包器 utoopack，将替代原有的 Mako 打包器，提供更快的构建性能和更完整的 Webpack 兼容性。
@@ -242,7 +242,7 @@
                 <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2025-04">2025-04</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
-                    <a href="https://mp.weixin.qq.com/s/Z0rDUkqPPTA8ijjOXN7d7A" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="生成式 UI：AI 时代体验技术生产新范式 - 在新窗口打开" data-zh="生成式 UI：AI 时代体验技术生产新范式" data-en="Generative UI: New Paradigm for Experience Technology Production in AI Era">生成式 UI：AI 时代体验技术生产新范式</a>
+                    <a href="https://mp.weixin.qq.com/s/Z0rDUkqPPTA8ijjOXN7d7A" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="生成式 UI：AI 时代体验技术生产新范式 - 在新窗口打开" data-aria-zh="生成式 UI：AI 时代体验技术生产新范式 - 在新窗口打开" data-aria-en="Generative UI: New Paradigm for Experience Technology Production in AI Era - Open in new window" data-zh="生成式 UI：AI 时代体验技术生产新范式" data-en="Generative UI: New Paradigm for Experience Technology Production in AI Era">生成式 UI：AI 时代体验技术生产新范式</a>
                   </h3>
                   <p class="text-sm tracking-wide" data-zh="黄兆嵩(山糕) · 探讨 AI 时代下生成式 UI 作为体验技术生产新范式的理念与实践。" data-en="Huang Zhaosong (Shan Gao) · Exploring the concept and practice of Generative UI as a new paradigm for experience technology production in the AI era.">
                     黄兆嵩(山糕) · 探讨 AI 时代下生成式 UI 作为体验技术生产新范式的理念与实践。
@@ -253,7 +253,7 @@
                 <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2025-02">2025-02</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
-                    <a href="https://mp.weixin.qq.com/s/upqdQ5X0_I0WXXLzbViyqQ" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="支付宝集福视觉盛宴背后的动效技术 - 在新窗口打开" data-zh="支付宝集福视觉盛宴背后的动效技术" data-en="Motion Effects Technology Behind Alipay's Visual Feast">支付宝集福视觉盛宴背后的动效技术</a>
+                    <a href="https://mp.weixin.qq.com/s/upqdQ5X0_I0WXXLzbViyqQ" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="支付宝集福视觉盛宴背后的动效技术 - 在新窗口打开" data-aria-zh="支付宝集福视觉盛宴背后的动效技术 - 在新窗口打开" data-aria-en="Motion Effects Technology Behind Alipay's Visual Feast - Open in new window" data-zh="支付宝集福视觉盛宴背后的动效技术" data-en="Motion Effects Technology Behind Alipay's Visual Feast">支付宝集福视觉盛宴背后的动效技术</a>
                   </h3>
                   <p class="text-sm tracking-wide" data-zh="Galacean Effects · 揭秘支付宝集五福视觉盛宴背后的动效技术实现。" data-en="Galacean Effects · Unveiling the motion effects technology behind Alipay's Five Blessings visual feast.">
                     Galacean Effects · 揭秘支付宝集五福视觉盛宴背后的动效技术实现。
@@ -275,9 +275,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://www.qmusespace.com/" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="QMuse 官网 - 在新窗口打开">QMuse</a>
+                    <a href="https://www.qmusespace.com/" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="QMuse 官网 - 在新窗口打开" data-aria-zh="QMuse 官网 - 在新窗口打开" data-aria-en="QMuse official website - Open in new window">QMuse</a>
                   </h3>
-                  <a href="https://www.qmusespace.com/" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="QMuse 官网 - 在新窗口打开" data-zh="访问 →" data-en="Visit →">访问 →</a>
+                  <a href="https://www.qmusespace.com/" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="QMuse 官网 - 在新窗口打开" data-aria-zh="QMuse 官网 - 在新窗口打开" data-aria-en="QMuse official website - Open in new window" data-zh="访问 →" data-en="Visit →">访问 →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="懂你的 QMuse，让灵感触手可及，让需求极速上线，让产物生产可用。" data-en="QMuse understands you — making inspiration within reach, shipping requirements at speed, and turning outputs production-ready.">
                   懂你的 QMuse，让灵感触手可及，让需求极速上线，让产物生产可用。
@@ -286,9 +286,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://idesign.alipay.com/" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="蚂上有创意 官网 - 在新窗口打开">蚂上有创意</a>
+                    <a href="https://idesign.alipay.com/" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="蚂上有创意 官网 - 在新窗口打开" data-aria-zh="蚂上有创意 官网 - 在新窗口打开" data-aria-en="Mashang Youchuangyi official website - Open in new window">蚂上有创意</a>
                   </h3>
-                  <a href="https://idesign.alipay.com/" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="蚂上有创意 官网 - 在新窗口打开" data-zh="访问 →" data-en="Visit →">访问 →</a>
+                  <a href="https://idesign.alipay.com/" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="蚂上有创意 官网 - 在新窗口打开" data-aria-zh="蚂上有创意 官网 - 在新窗口打开" data-aria-en="Mashang Youchuangyi official website - Open in new window" data-zh="访问 →" data-en="Visit →">访问 →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="为营销而生的 AI 创意生成平台，借助 AI 快速产出高质量营销创意内容。" data-en="An AI creative generation platform built for marketing, producing high-quality marketing content quickly with AI.">
                   为营销而生的 AI 创意生成平台，借助 AI 快速产出高质量营销创意内容。
@@ -297,9 +297,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://npmmirror.com/" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="npmmirror 镜像站 官网 - 在新窗口打开">npmmirror 镜像站</a>
+                    <a href="https://npmmirror.com/" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="npmmirror 镜像站 官网 - 在新窗口打开" data-aria-zh="npmmirror 镜像站 官网 - 在新窗口打开" data-aria-en="npmmirror official website - Open in new window">npmmirror 镜像站</a>
                   </h3>
-                  <a href="https://npmmirror.com/" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="npmmirror 镜像站 官网 - 在新窗口打开" data-zh="访问 →" data-en="Visit →">访问 →</a>
+                  <a href="https://npmmirror.com/" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="npmmirror 镜像站 官网 - 在新窗口打开" data-aria-zh="npmmirror 镜像站 官网 - 在新窗口打开" data-aria-en="npmmirror official website - Open in new window" data-zh="访问 →" data-en="Visit →">访问 →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="npm 的完整只读镜像站，与官方实时同步，为国内开发者提供稳定快速的包下载加速服务。" data-en="A complete read-only mirror of npm, synced with the official registry in real time, providing fast and stable package download acceleration for developers in China.">
                   npm 的完整只读镜像站，与官方实时同步，为国内开发者提供稳定快速的包下载加速服务。
@@ -317,9 +317,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://github.com/ant-design/" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="Ant Design GitHub 仓库 - 在新窗口打开">Ant Design</a>
+                    <a href="https://github.com/ant-design/" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="Ant Design GitHub 仓库 - 在新窗口打开" data-aria-zh="Ant Design GitHub 仓库 - 在新窗口打开" data-aria-en="Ant Design GitHub repository - Open in new window">Ant Design</a>
                   </h3>
-                  <a href="https://github.com/ant-design/" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="Ant Design GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                  <a href="https://github.com/ant-design/" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="Ant Design GitHub 仓库 - 在新窗口打开" data-aria-zh="Ant Design GitHub 仓库 - 在新窗口打开" data-aria-en="Ant Design GitHub repository - Open in new window">GitHub →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="企业级 UI 设计语言和 React 组件库，提供丰富的组件和设计规范，广泛应用于企业级产品开发。" data-en="Enterprise-level UI design language and React component library, providing rich components and design specifications, widely used in enterprise product development.">
                   企业级 UI 设计语言和 React 组件库，提供丰富的组件和设计规范，广泛应用于企业级产品开发。
@@ -328,9 +328,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://github.com/eggjs/egg" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="Egg.js GitHub 仓库 - 在新窗口打开">Egg.js</a>
+                    <a href="https://github.com/eggjs/egg" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="Egg.js GitHub 仓库 - 在新窗口打开" data-aria-zh="Egg.js GitHub 仓库 - 在新窗口打开" data-aria-en="Egg.js GitHub repository - Open in new window">Egg.js</a>
                   </h3>
-                  <a href="https://github.com/eggjs/egg" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="Egg.js GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                  <a href="https://github.com/eggjs/egg" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="Egg.js GitHub 仓库 - 在新窗口打开" data-aria-zh="Egg.js GitHub 仓库 - 在新窗口打开" data-aria-en="Egg.js GitHub repository - Open in new window">GitHub →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="企业级 Node.js 框架，提供强大的插件机制和约定优于配置的开发体验，适合构建大型应用。" data-en="Enterprise-level Node.js framework, providing powerful plugin mechanisms and convention-over-configuration development experience, suitable for building large applications.">
                   企业级 Node.js 框架，提供强大的插件机制和约定优于配置的开发体验，适合构建大型应用。
@@ -339,9 +339,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://github.com/umijs/qiankun" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="qiankun GitHub 仓库 - 在新窗口打开">qiankun</a>
+                    <a href="https://github.com/umijs/qiankun" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="qiankun GitHub 仓库 - 在新窗口打开" data-aria-zh="qiankun GitHub 仓库 - 在新窗口打开" data-aria-en="qiankun GitHub repository - Open in new window">qiankun</a>
                   </h3>
-                  <a href="https://github.com/umijs/qiankun" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="qiankun GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                  <a href="https://github.com/umijs/qiankun" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="qiankun GitHub 仓库 - 在新窗口打开" data-aria-zh="qiankun GitHub 仓库 - 在新窗口打开" data-aria-en="qiankun GitHub repository - Open in new window">GitHub →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="基于 single-spa 的微前端实现库，提供完整的微前端解决方案，支持多种框架和技术栈。" data-en="Micro-frontend implementation library based on single-spa, providing complete micro-frontend solutions, supporting multiple frameworks and technology stacks.">
                   基于 single-spa 的微前端实现库，提供完整的微前端解决方案，支持多种框架和技术栈。
@@ -350,9 +350,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://github.com/umijs/umi" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="umi GitHub 仓库 - 在新窗口打开">umi</a>
+                    <a href="https://github.com/umijs/umi" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="umi GitHub 仓库 - 在新窗口打开" data-aria-zh="umi GitHub 仓库 - 在新窗口打开" data-aria-en="umi GitHub repository - Open in new window">umi</a>
                   </h3>
-                  <a href="https://github.com/umijs/umi" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="umi GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                  <a href="https://github.com/umijs/umi" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="umi GitHub 仓库 - 在新窗口打开" data-aria-zh="umi GitHub 仓库 - 在新窗口打开" data-aria-en="umi GitHub repository - Open in new window">GitHub →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="可插拔的企业级 React 应用框架，提供路由、构建、部署等完整的开发解决方案。" data-en="Pluggable enterprise-level React application framework, providing complete development solutions including routing, building, and deployment.">
                   可插拔的企业级 React 应用框架，提供路由、构建、部署等完整的开发解决方案。
@@ -361,9 +361,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://github.com/umijs/dumi" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="dumi GitHub 仓库 - 在新窗口打开">dumi</a>
+                    <a href="https://github.com/umijs/dumi" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="dumi GitHub 仓库 - 在新窗口打开" data-aria-zh="dumi GitHub 仓库 - 在新窗口打开" data-aria-en="dumi GitHub repository - Open in new window">dumi</a>
                   </h3>
-                  <a href="https://github.com/umijs/dumi" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="dumi GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                  <a href="https://github.com/umijs/dumi" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="dumi GitHub 仓库 - 在新窗口打开" data-aria-zh="dumi GitHub 仓库 - 在新窗口打开" data-aria-en="dumi GitHub repository - Open in new window">GitHub →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="为组件研发而生的静态站点框架，专注于组件文档的展示和管理，支持多种文档格式。" data-en="Static site framework born for component development, focusing on component documentation display and management, supporting multiple documentation formats.">
                   为组件研发而生的静态站点框架，专注于组件文档的展示和管理，支持多种文档格式。
@@ -372,9 +372,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://github.com/utooland/utoo" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="utoo GitHub 仓库 - 在新窗口打开">utoo</a>
+                    <a href="https://github.com/utooland/utoo" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="utoo GitHub 仓库 - 在新窗口打开" data-aria-zh="utoo GitHub 仓库 - 在新窗口打开" data-aria-en="utoo GitHub repository - Open in new window">utoo</a>
                   </h3>
-                  <a href="https://github.com/utooland/utoo" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="utoo GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                  <a href="https://github.com/utooland/utoo" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="utoo GitHub 仓库 - 在新窗口打开" data-aria-zh="utoo GitHub 仓库 - 在新窗口打开" data-aria-en="utoo GitHub repository - Open in new window">GitHub →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="Web 开发的统一工具链，提供一站式的开发体验和工具集成。" data-en="An unified toolchain for web development, providing one-stop development experience and tool integration.">
                   Web 开发的统一工具链，提供一站式的开发体验和工具集成。
@@ -383,9 +383,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://github.com/cnpm/cnpm" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="cnpm GitHub 仓库 - 在新窗口打开">cnpm</a>
+                    <a href="https://github.com/cnpm/cnpm" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="cnpm GitHub 仓库 - 在新窗口打开" data-aria-zh="cnpm GitHub 仓库 - 在新窗口打开" data-aria-en="cnpm GitHub repository - Open in new window">cnpm</a>
                   </h3>
-                  <a href="https://github.com/cnpm/cnpm" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="cnpm GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                  <a href="https://github.com/cnpm/cnpm" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="cnpm GitHub 仓库 - 在新窗口打开" data-aria-zh="cnpm GitHub 仓库 - 在新窗口打开" data-aria-en="cnpm GitHub repository - Open in new window">GitHub →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="npm 的中国镜像客户端，为中国前端开发者提供更快的包管理体验和镜像服务。" data-en="npm's China mirror client, providing Chinese frontend developers with faster package management experience and mirror services.">
                   npm 的中国镜像客户端，为中国前端开发者提供更快的包管理体验和镜像服务。
@@ -394,9 +394,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://github.com/afx-team/petercat" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="PeterCat GitHub 仓库 - 在新窗口打开">PeterCat</a>
+                    <a href="https://github.com/afx-team/petercat" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="PeterCat GitHub 仓库 - 在新窗口打开" data-aria-zh="PeterCat GitHub 仓库 - 在新窗口打开" data-aria-en="PeterCat GitHub repository - Open in new window">PeterCat</a>
                   </h3>
-                  <a href="https://github.com/afx-team/petercat" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="PeterCat GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                  <a href="https://github.com/afx-team/petercat" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="PeterCat GitHub 仓库 - 在新窗口打开" data-aria-zh="PeterCat GitHub 仓库 - 在新窗口打开" data-aria-en="PeterCat GitHub repository - Open in new window">GitHub →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="一个对话式问答代理配置系统，提供自托管部署解决方案和便捷的一体化应用 SDK，让你为 GitHub 仓库创建智能问答机器人。" data-en="A conversational Q&A agent configuration system, self-hosted deployment solutions, and a convenient all-in-one application SDK, allowing you to create intelligent Q&A bots for your GitHub repositories.">
                   一个对话式问答代理配置系统，提供自托管部署解决方案和便捷的一体化应用 SDK，让你为 GitHub 仓库创建智能问答机器人。
@@ -405,9 +405,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://github.com/galacean/effects-runtime" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="Galacean Effects GitHub 仓库 - 在新窗口打开">Galacean Effects</a>
+                    <a href="https://github.com/galacean/effects-runtime" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="Galacean Effects GitHub 仓库 - 在新窗口打开" data-aria-zh="Galacean Effects GitHub 仓库 - 在新窗口打开" data-aria-en="Galacean Effects GitHub repository - Open in new window">Galacean Effects</a>
                   </h3>
-                  <a href="https://github.com/galacean/effects-runtime" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="Galacean Effects GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                  <a href="https://github.com/galacean/effects-runtime" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="Galacean Effects GitHub 仓库 - 在新窗口打开" data-aria-zh="Galacean Effects GitHub 仓库 - 在新窗口打开" data-aria-en="Galacean Effects GitHub repository - Open in new window">GitHub →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="快速轻松地制作动效，为前端开发者和设计师提供强大的动画制作工具和效果库。" data-en="Quickly and easily create motion effects, providing frontend developers and designers with powerful animation tools and effects library.">
                   快速轻松地制作动效，为前端开发者和设计师提供强大的动画制作工具和效果库。
@@ -416,9 +416,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://github.com/neovateai/neovate-code" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="Neovate Code GitHub 仓库 - 在新窗口打开">Neovate Code</a>
+                    <a href="https://github.com/neovateai/neovate-code" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="Neovate Code GitHub 仓库 - 在新窗口打开" data-aria-zh="Neovate Code GitHub 仓库 - 在新窗口打开" data-aria-en="Neovate Code GitHub repository - Open in new window">Neovate Code</a>
                   </h3>
-                  <a href="https://github.com/neovateai/neovate-code" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="Neovate Code GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                  <a href="https://github.com/neovateai/neovate-code" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="Neovate Code GitHub 仓库 - 在新窗口打开" data-aria-zh="Neovate Code GitHub 仓库 - 在新窗口打开" data-aria-en="Neovate Code GitHub repository - Open in new window">GitHub →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="代码智能助手，可以用来生成代码、修复错误、审查代码、添加测试等，支持交互模式和无头模式。" data-en="Code agent to enhance your development. You can use it to generate code, fix bugs, review code, add tests, and more. You can run it in interactive mode or headless mode.">
                   代码智能助手，可以用来生成代码、修复错误、审查代码、添加测试等，支持交互模式和无头模式。
@@ -427,9 +427,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://github.com/unieojs/unieo" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="Unieo GitHub 仓库 - 在新窗口打开">Unieo</a>
+                    <a href="https://github.com/unieojs/unieo" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="Unieo GitHub 仓库 - 在新窗口打开" data-aria-zh="Unieo GitHub 仓库 - 在新窗口打开" data-aria-en="Unieo GitHub repository - Open in new window">Unieo</a>
                   </h3>
-                  <a href="https://github.com/unieojs/unieo" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="Unieo GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                  <a href="https://github.com/unieojs/unieo" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="Unieo GitHub 仓库 - 在新窗口打开" data-aria-zh="Unieo GitHub 仓库 - 在新窗口打开" data-aria-en="Unieo GitHub repository - Open in new window">GitHub →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="一个基于模式驱动的边缘计算环境路由引擎。" data-en="A pattern-driven routing engine for edge computing environments.">
                   一个基于模式驱动的边缘计算环境路由引擎。
@@ -438,9 +438,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://github.com/afx-team/WhiskerRAG" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="WhiskerRAG GitHub 仓库 - 在新窗口打开">WhiskerRAG</a>
+                    <a href="https://github.com/afx-team/WhiskerRAG" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="WhiskerRAG GitHub 仓库 - 在新窗口打开" data-aria-zh="WhiskerRAG GitHub 仓库 - 在新窗口打开" data-aria-en="WhiskerRAG GitHub repository - Open in new window">WhiskerRAG</a>
                   </h3>
-                  <a href="https://github.com/afx-team/WhiskerRAG" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="WhiskerRAG GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                  <a href="https://github.com/afx-team/WhiskerRAG" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="WhiskerRAG GitHub 仓库 - 在新窗口打开" data-aria-zh="WhiskerRAG GitHub 仓库 - 在新窗口打开" data-aria-en="WhiskerRAG GitHub repository - Open in new window">GitHub →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="轻量级且灵活的 RAG（检索增强生成）框架，提供高效的知识检索和生成能力。" data-en="A lightweight and flexible RAG (Retrieval-Augmented Generation) framework.">
                   轻量级且灵活的 RAG（检索增强生成）框架，提供高效的知识检索和生成能力。
@@ -449,9 +449,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://github.com/afx-team/UI-UG" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="UI-UG GitHub 仓库 - 在新窗口打开">UI-UG</a>
+                    <a href="https://github.com/afx-team/UI-UG" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="UI-UG GitHub 仓库 - 在新窗口打开" data-aria-zh="UI-UG GitHub 仓库 - 在新窗口打开" data-aria-en="UI-UG GitHub repository - Open in new window">UI-UG</a>
                   </h3>
-                  <a href="https://github.com/afx-team/UI-UG" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="UI-UG GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                  <a href="https://github.com/afx-team/UI-UG" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="UI-UG GitHub 仓库 - 在新窗口打开" data-aria-zh="UI-UG GitHub 仓库 - 在新窗口打开" data-aria-en="UI-UG GitHub repository - Open in new window">GitHub →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="首个统一UI理解与UI生成的多模态大模型，在元素分类、OCR识别、颜色识别、定位等多模态任务准确率均达SOTA，支持UI理解和生成两大核心能力。" data-en="The first multimodal large model unifying UI understanding and generation, achieving SOTA accuracy in multimodal tasks including element classification, OCR, color recognition, and positioning, supporting both UI understanding and generation capabilities.">
                   首个统一UI理解与UI生成的多模态大模型，在元素分类、OCR识别、颜色识别、定位等多模态任务准确率均达SOTA，支持UI理解和生成两大核心能力。
@@ -460,9 +460,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://github.com/afx-team/UI-UX" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="UI-UX GitHub 仓库 - 在新窗口打开">UI-UX</a>
+                    <a href="https://github.com/afx-team/UI-UX" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="UI-UX GitHub 仓库 - 在新窗口打开" data-aria-zh="UI-UX GitHub 仓库 - 在新窗口打开" data-aria-en="UI-UX GitHub repository - Open in new window">UI-UX</a>
                   </h3>
-                  <a href="https://github.com/afx-team/UI-UX" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="UI-UX GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                  <a href="https://github.com/afx-team/UI-UX" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="UI-UX GitHub 仓库 - 在新窗口打开" data-aria-zh="UI-UX GitHub 仓库 - 在新窗口打开" data-aria-en="UI-UX GitHub repository - Open in new window">GitHub →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="面向移动端 UX 缺陷诊断的 4B 多模态大模型，提出 UXBench——首个面向 UX 推理的视觉语言基准测试，在 UXBench 上以 79.63% 的准确率超越 Claude 等前沿模型（CVPR 2026 Findings）。" data-en="A 4B multimodal LLM for mobile UX defect diagnosis, introducing UXBench — the first vision–language benchmark for UX reasoning. UI-UX achieves 79.63% accuracy on UXBench, surpassing Claude and other frontier models (CVPR 2026 Findings).">
                   面向移动端 UX 缺陷诊断的 4B 多模态大模型，提出 UXBench——首个面向 UX 推理的视觉语言基准测试，在 UXBench 上以 79.63% 的准确率超越 Claude 等前沿模型（CVPR 2026 Findings）。
@@ -471,9 +471,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://github.com/afx-team/evjs" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="evjs GitHub 仓库 - 在新窗口打开">evjs</a>
+                    <a href="https://github.com/afx-team/evjs" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="evjs GitHub 仓库 - 在新窗口打开" data-aria-zh="evjs GitHub 仓库 - 在新窗口打开" data-aria-en="evjs GitHub repository - Open in new window">evjs</a>
                   </h3>
-                  <a href="https://github.com/afx-team/evjs" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="evjs GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                  <a href="https://github.com/afx-team/evjs" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="evjs GitHub 仓库 - 在新窗口打开" data-aria-zh="evjs GitHub 仓库 - 在新窗口打开" data-aria-en="evjs GitHub repository - Open in new window">GitHub →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="基于 TanStack 和 Hono 构建的 React 全栈框架，约定优于配置，支持类型安全路由、服务端函数和多运行时部署。" data-en="A React full-stack framework built on TanStack and Hono, with convention over configuration, type-safe routing, server functions, and multi-runtime deployment.">
                   基于 TanStack 和 Hono 构建的 React 全栈框架，约定优于配置，支持类型安全路由、服务端函数和多运行时部署。
@@ -482,9 +482,9 @@
               <article class="pb-1" role="listitem">
                 <div class="flex justify-between items-start mb-1">
                   <h3 class="font-semibold text-base tracking-wide">
-                    <a href="https://github.com/afx-team/hebb-mind" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="Hebb Mind GitHub 仓库 - 在新窗口打开">Hebb Mind</a>
+                    <a href="https://github.com/afx-team/hebb-mind" target="_blank" rel="noopener noreferrer" class="hover:text-black" aria-label="Hebb Mind GitHub 仓库 - 在新窗口打开" data-aria-zh="Hebb Mind GitHub 仓库 - 在新窗口打开" data-aria-en="Hebb Mind GitHub repository - Open in new window">Hebb Mind</a>
                   </h3>
-                  <a href="https://github.com/afx-team/hebb-mind" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="Hebb Mind GitHub 仓库 - 在新窗口打开">GitHub →</a>
+                  <a href="https://github.com/afx-team/hebb-mind" target="_blank" rel="noopener noreferrer" class="text-sm text-gray-600 tracking-wide" aria-label="Hebb Mind GitHub 仓库 - 在新窗口打开" data-aria-zh="Hebb Mind GitHub 仓库 - 在新窗口打开" data-aria-en="Hebb Mind GitHub repository - Open in new window">GitHub →</a>
                 </div>
                 <p class="text-sm mb-1 tracking-wide" data-zh="受神经科学启发的 AI 智能体记忆框架，模拟大脑的记忆循环（编码、整合、激活、遗忘），为智能体提供长期记忆能力。" data-en="A neuroscience-inspired memory framework for AI agents that mimics the brain's memory loop (encode, consolidate, activate, forget), giving agents long-term memory.">
                   受神经科学启发的 AI 智能体记忆框架，模拟大脑的记忆循环（编码、整合、激活、遗忘），为智能体提供长期记忆能力。
@@ -503,7 +503,7 @@
             </h2>
             <div class="space-y-1" role="list">
               <article class="flex justify-between items-center py-1" role="listitem">
-                <a href="https://v2ex.com/t/1217346" target="_blank" rel="noopener noreferrer" class="font-medium text-base tracking-wide hover:text-black" aria-label="前端工程师实习生（2027 届）" data-zh="前端工程师实习生（2027 届）" data-en="Frontend Engineer Intern (2027)">前端工程师实习生（2027 届）</a>
+                <a href="https://v2ex.com/t/1217346" target="_blank" rel="noopener noreferrer" class="font-medium text-base tracking-wide hover:text-black" aria-label="前端工程师实习生（2027 届） - 在新窗口打开" data-aria-zh="前端工程师实习生（2027 届） - 在新窗口打开" data-aria-en="Frontend Engineer Intern (2027) - Open in new window" data-zh="前端工程师实习生（2027 届）" data-en="Frontend Engineer Intern (2027)">前端工程师实习生（2027 届）</a>
               </article>
             </div>
             <aside class="mt-2 p-2 bg-gray-50 border-l-2 border-gray-400">
@@ -554,15 +554,15 @@
               <h3 id="contact-heading" class="text-lg font-bold mb-1 border-b border-black pb-1 tracking-wide" data-zh="关注我们" data-en="Follow Us">关注我们</h3>
               <div class="text-sm tracking-wide" role="list">
                 <div role="listitem" class="flex items-center space-x-2">
-                  <a href="https://space.bilibili.com/487703803" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="B站主页 - 在新窗口打开" data-zh="B站" data-en="Bilibili">B站</a>
+                  <a href="https://space.bilibili.com/487703803" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="B站主页 - 在新窗口打开" data-aria-zh="B站主页 - 在新窗口打开" data-aria-en="Bilibili homepage - Open in new window" data-zh="B站" data-en="Bilibili">B站</a>
                   <span class="text-gray-400">·</span>
-                  <a href="https://www.zhihu.com/people/antdx" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="知乎主页 - 在新窗口打开" data-zh="知乎" data-en="Zhihu">知乎</a>
+                  <a href="https://www.zhihu.com/people/antdx" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="知乎主页 - 在新窗口打开" data-aria-zh="知乎主页 - 在新窗口打开" data-aria-en="Zhihu homepage - Open in new window" data-zh="知乎" data-en="Zhihu">知乎</a>
                   <span class="text-gray-400">·</span>
-                  <a href="https://juejin.cn/user/2629687543097592" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="掘金主页 - 在新窗口打开" data-zh="掘金" data-en="Juejin">掘金</a>
+                  <a href="https://juejin.cn/user/2629687543097592" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="掘金主页 - 在新窗口打开" data-aria-zh="掘金主页 - 在新窗口打开" data-aria-en="Juejin homepage - Open in new window" data-zh="掘金" data-en="Juejin">掘金</a>
                   <span class="text-gray-400">·</span>
-                  <a href="https://mdn.alipayobjects.com/huamei_fkc4p0/afts/img/A*UOEmSZ2MvMQAAAAAQvAAAAgAeobDAQ/original" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="公众号二维码 - 在新窗口打开" data-zh="公众号" data-en="WeChat">公众号</a>
+                  <a href="https://mdn.alipayobjects.com/huamei_fkc4p0/afts/img/A*UOEmSZ2MvMQAAAAAQvAAAAgAeobDAQ/original" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="公众号二维码 - 在新窗口打开" data-aria-zh="公众号二维码 - 在新窗口打开" data-aria-en="WeChat QR code - Open in new window" data-zh="公众号" data-en="WeChat">公众号</a>
                   <span class="text-gray-400">·</span>
-                  <a href="https://github.com/afx-team/afx-team.github.io" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="GitHub 主页 - 在新窗口打开" data-zh="GitHub" data-en="GitHub">GitHub</a>
+                  <a href="https://github.com/afx-team/afx-team.github.io" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="GitHub 主页 - 在新窗口打开" data-aria-zh="GitHub 主页 - 在新窗口打开" data-aria-en="GitHub homepage - Open in new window" data-zh="GitHub" data-en="GitHub">GitHub</a>
                   <span class="text-gray-400">·</span>
                   <a href="#" id="lang-toggle" class="text-gray-700 hover:text-black" aria-label="切换语言" data-zh="EN" data-en="中文">EN</a>
                 </div>

--- a/index.html
+++ b/index.html
@@ -231,7 +231,7 @@
                 <time class="text-sm text-gray-600 min-w-[60px] mr-2 font-medium" datetime="2025-04">2025-04</time>
                 <div>
                   <h3 class="font-semibold text-base mb-1 tracking-wide">
-                    <a href="https://github.com/umijs/mako/issues/1872" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="Mako Next: A new bundler on top of Turbopack - 在新窗口打开" data-aria-zh="Mako Next: A new bundler on top of Turbopack - 在新窗口打开" data-aria-en="[Mako Next]: A new bundler on top of Turbopack - Open in new window" data-zh="[Mako Next]: A new bundler on top of Turbopack" data-en="[Mako Next]: A new bundler on top of Turbopack">[Mako Next]: A new bundler on top of Turbopack</a>
+                    <a href="https://github.com/umijs/mako/issues/1872" target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:text-black" aria-label="[Mako Next]: A new bundler on top of Turbopack - 在新窗口打开" data-aria-zh="[Mako Next]: A new bundler on top of Turbopack - 在新窗口打开" data-aria-en="[Mako Next]: A new bundler on top of Turbopack - Open in new window" data-zh="[Mako Next]: A new bundler on top of Turbopack" data-en="[Mako Next]: A new bundler on top of Turbopack">[Mako Next]: A new bundler on top of Turbopack</a>
                   </h3>
                   <p class="text-sm tracking-wide" data-zh="发布基于 Turbopack 的新打包器 utoopack，将替代原有的 Mako 打包器，提供更快的构建性能和更完整的 Webpack 兼容性。" data-en="Release of utoopack, a new bundler based on Turbopack, which will replace the original Mako bundler, providing faster build performance and more complete Webpack compatibility.">
                     发布基于 Turbopack 的新打包器 utoopack，将替代原有的 Mako 打包器，提供更快的构建性能和更完整的 Webpack 兼容性。

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -105,6 +105,16 @@ class I18nManager {
           : element.getAttribute('data-en');
       element.textContent = text;
     });
+
+    document
+      .querySelectorAll('[data-aria-zh][data-aria-en]')
+      .forEach((element) => {
+        const label =
+          lang === 'zh'
+            ? element.getAttribute('data-aria-zh')
+            : element.getAttribute('data-aria-en');
+        element.setAttribute('aria-label', label);
+      });
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "AFX Team 官方网站",
   "scripts": {
+    "test": "node --test",
     "format": "biome format --write .",
     "lint": "biome lint .",
     "check": "biome check --write .",

--- a/tests/aria-label-i18n.test.mjs
+++ b/tests/aria-label-i18n.test.mjs
@@ -42,6 +42,19 @@ test('external links provide localized aria-label values', () => {
       /[\u4e00-\u9fff]/,
       `English aria-label contains Chinese text: ${tag}`
     );
+
+    if (
+      attributes['data-zh'] &&
+      attributes['data-en'] &&
+      attributes['data-aria-en'] ===
+        `${attributes['data-en']} - Open in new window`
+    ) {
+      assert.equal(
+        attributes['data-aria-zh'],
+        `${attributes['data-zh']} - 在新窗口打开`,
+        `localized title aria-label does not match data-zh: ${tag}`
+      );
+    }
   }
 });
 

--- a/tests/aria-label-i18n.test.mjs
+++ b/tests/aria-label-i18n.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+const i18nScript = readFileSync(
+  new URL('../js/i18n.js', import.meta.url),
+  'utf8'
+);
+
+function parseAttributes(tag) {
+  const attributes = {};
+  const attrPattern = /([\w:-]+)(?:="([^"]*)")?/g;
+
+  for (const [, name, value = ''] of tag.matchAll(attrPattern)) {
+    if (name !== 'a') {
+      attributes[name] = value;
+    }
+  }
+
+  return attributes;
+}
+
+function getExternalLinks() {
+  return [...html.matchAll(/<a\b[^>]*>/g)]
+    .map(([tag]) => ({ tag, attributes: parseAttributes(tag) }))
+    .filter(({ attributes }) => attributes.target === '_blank');
+}
+
+test('external links provide localized aria-label values', () => {
+  const externalLinks = getExternalLinks();
+
+  assert.ok(externalLinks.length > 0, 'expected external links in index.html');
+
+  for (const { tag, attributes } of externalLinks) {
+    assert.ok(attributes['aria-label'], `missing aria-label: ${tag}`);
+    assert.ok(attributes['data-aria-zh'], `missing data-aria-zh: ${tag}`);
+    assert.ok(attributes['data-aria-en'], `missing data-aria-en: ${tag}`);
+    assert.equal(attributes['aria-label'], attributes['data-aria-zh']);
+    assert.doesNotMatch(
+      attributes['data-aria-en'],
+      /[\u4e00-\u9fff]/,
+      `English aria-label contains Chinese text: ${tag}`
+    );
+  }
+});
+
+test('language switch updates localized aria-label values', () => {
+  assert.match(i18nScript, /\[data-aria-zh\]\[data-aria-en\]/);
+  assert.match(i18nScript, /setAttribute\(\s*['"]aria-label['"]/);
+});


### PR DESCRIPTION
## Summary

- Add localized `data-aria-zh` / `data-aria-en` values for external links that open in a new window.
- Update the language switcher to sync `aria-label` alongside visible text.
- Add a Node test that guards external-link aria-label localization.

Closes #15

## Verification

- `npm test`
- `npx biome lint index.html js/i18n.js tests/aria-label-i18n.test.mjs`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced multilingual accessibility for external links by adding language-aware “open in new window” labeling to improve screen-reader clarity in both Chinese and English.
* **Tests**
  * Added automated checks to ensure external links include the new accessibility/i18n attributes and that the correct language-specific aria labeling is applied.
* **Chores**
  * Added a `test` script to run the Node-based test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->